### PR TITLE
Merge branch 'master' into Programming/arreglos-amarillo

### DIFF
--- a/Lectos-CreaEdition/Assets/PruebasAndres/ScriptsAndres/CreateLevel.cs
+++ b/Lectos-CreaEdition/Assets/PruebasAndres/ScriptsAndres/CreateLevel.cs
@@ -457,10 +457,8 @@ public class CreateLevel : MonoBehaviour
         if (terminadoPorPuntaje){
             //InterfazFinMinijuego.SetActive(true);
             InterfazFinMinijuego.GetComponent<ManagerAnimations>().OnAnimationIn();
-<<<<<<< HEAD
             GetComponent<Tiempo>().Terminar();
         }       
-=======
             if (SwitchButtonEndGame) {
                 if (siguienteNivel != null) {
                     InterfazFinMinijuego.transform.Find("LunaTerminada").GetComponent<ScaleAnimationInOut>().InAnimation();
@@ -469,10 +467,7 @@ public class CreateLevel : MonoBehaviour
             else {
                 siguienteNivel.GetComponent<ScaleAnimationInOut>().InAnimation();
             }
-        }
-        
-        
->>>>>>> master
+              
     }
 
     void CambiarReceptor ()


### PR DESCRIPTION
# Conflicts:
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-buñuelo0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-dadiva0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-dado0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-daga.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-daño.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-dedo.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-dinosaurio.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-divan.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-domino.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-doña.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-ducha.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-faro.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-feliz.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-ficha.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-fila.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-foto.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-futbol.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-galleta.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-gato.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-gelatina.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-gigante.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-guayo.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-gusano.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-jamon.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-jarra0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-jinete.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-jirafa.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-joya0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-jugo0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-llanta0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-llaves.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-lleva0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-llora0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-lluvia0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-mofa.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-mono.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-mora0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-nina0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-pinata0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-rama0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-rana0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-rancho0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-remo0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-risa0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-rojo0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-rueda0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-sueño0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-uva0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-uña0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-vaca0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-vagon0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-vela0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-vigia0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-villa0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-vino0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-volcan0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-vuela0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-yate0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-yema0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-yoga0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-yoyo0.mp3.meta
#	Lectos-CreaEdition/Assets/Audio/01-crea-2020/onomatopetas/a-yudo0.mp3.meta
#	Lectos-CreaEdition/Assets/PruebasAndres/ScriptsAndres/CreateLevel.cs